### PR TITLE
add Aquiles-Image to Image Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you'd like to be featured, submit a PR!
 | [comfy-deploy/models](https://github.com/comfy-deploy/models) | Optimized ComfyUI-based cloud deployments |
 | [qart-codes](https://github.com/charlesfrye/qart-codes) | QR Codes with aesthetically-pleasing corruptions |
 | [Fooocus-Modal](https://github.com/BarrenWardo/Fooocus-Modal) | Deploy Fooocus diffuser apps on Modal |
+| [Aquiles-Image](https://github.com/Aquiles-ai/Aquiles-Image) | OpenAI-compatible inference server for FLUX, SD3.5, Wan2.x and more |
 
 ## LLMs/Multimodal Models
 


### PR DESCRIPTION
### Description

Adds [Aquiles-Image](https://github.com/Aquiles-ai/Aquiles-Image) to the Image Generation section.

Aquiles-Image is an OpenAI-compatible inference server for diffusion models built on FastAPI and Diffusers. It supports 30+ models including FLUX, FLUX.2-klein, Stable Diffusion 3.5, and video models like Wan2.x and HunyuanVideo, and comes with a built-in playground for testing.

We use and recommend Modal as our deployment platform. All the examples in our [`example/`](https://github.com/Aquiles-ai/Aquiles-Image/tree/main/example) folder deploy on Modal, and we also have a deployment example in `modal-labs/modal-examples` under `misc/aquiles_image_server.py`.

Thanks for the consideration!