### PR TITLE
Add modal-uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ If you'd like to be featured, submit a PR!
 | [ZenML's Modal integration](https://docs.zenml.io/stack-components/step-operators/modal) | Run your ZenML pipelines on Modal |
 | [Run Metabase on Modal](https://github.com/anthonycorletti/modal-metabase) | Run your data vis and analytics dashboards near your data pipelines on Modal  |
 | [moonshopping](https://github.com/ranfysvalle02/moonshopping) | Shareable wishlists using MongoDB and Modal  |
-| [modal-uv](https://github.com/ofekby/modal-uv) | Run `uv` commands and shell scripts on Modal |
+| [modal-uv](https://github.com/ofekby/modal-uv) | CLI and skill for running `uv` commands and shell scripts on Modal |

--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ If you'd like to be featured, submit a PR!
 | [ZenML's Modal integration](https://docs.zenml.io/stack-components/step-operators/modal) | Run your ZenML pipelines on Modal |
 | [Run Metabase on Modal](https://github.com/anthonycorletti/modal-metabase) | Run your data vis and analytics dashboards near your data pipelines on Modal  |
 | [moonshopping](https://github.com/ranfysvalle02/moonshopping) | Shareable wishlists using MongoDB and Modal  |
+| [modal-uv](https://github.com/ofekby/modal-uv) | Agentic-first CLI to run `uv` commands and shell scripts on Modal GPUs or CPU — file sync, async execution, and persistent volumes for remote compilation, CUDA, and training |

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ If you'd like to be featured, submit a PR!
 | [ZenML's Modal integration](https://docs.zenml.io/stack-components/step-operators/modal) | Run your ZenML pipelines on Modal |
 | [Run Metabase on Modal](https://github.com/anthonycorletti/modal-metabase) | Run your data vis and analytics dashboards near your data pipelines on Modal  |
 | [moonshopping](https://github.com/ranfysvalle02/moonshopping) | Shareable wishlists using MongoDB and Modal  |
-| [modal-uv](https://github.com/ofekby/modal-uv) | Agentic-first CLI to run `uv` commands and shell scripts on Modal GPUs or CPU — file sync, async execution, and persistent volumes for remote compilation, CUDA, and training |
+| [modal-uv](https://github.com/ofekby/modal-uv) | Run `uv` commands and shell scripts on Modal |


### PR DESCRIPTION
Adds [modal-uv](https://github.com/ofekby/modal-uv) — an agentic-first CLI that lets you run ordinary `uv` workflows on Modal GPUs without turning your project into a Modal app.

Keeps the local development loop intact: file sync, lazy app deployment, async execution IDs, logs, abort, and persistent volumes.

Ships with a packaged agent skill — `modal-uv onboard` auto-installs it to detected coding agents (opencode, Claude Code, Gemini CLI) so they can use modal-uv without manual docs lookup.

Includes runnable [playbooks](https://github.com/ofekby/modal-uv/tree/main/playbooks) demonstrating:
- 64-CPU RocksDB static library compilation
- CUDA kernel compilation on a remote T4 (no local CUDA needed)
- MNIST CNN training on a remote T4

Also supports `modal-uv exec -- ...` for shell-style commands on the synced container.